### PR TITLE
added the ability to use custom colors by extending the default color…

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ with the `hover` variant will remain while all previous ones are dropped.
 
 Now we have a red button, as we intended!
 
+#### Using Custom Colors
+
+If you are defining custom colors in you tailwind.config.js file, you can extend the colors that Twix will recognize by adding the following to your config.exs file:
+```elixir
+config :twix, colors: ["my_first_custom_color", "my_second_custom_color", "etc"]
+``
+```
+
 ## Installation
 
 This package can be installed by adding `twix` to your

--- a/lib/twix/config_utils.ex
+++ b/lib/twix/config_utils.ex
@@ -46,6 +46,19 @@ defmodule Twix.ConfigUtils do
         pink: [{Twix.Validate, :is_integer?}, {Twix.Validate, :is_opacity?}],
         rose: [{Twix.Validate, :is_integer?}, {Twix.Validate, :is_opacity?}]
       }
+      |> extend(Application.get_env(:twix, :colors))
     ]
+  end
+
+  defp extend(color_map, nil), do: color_map
+
+  defp extend(color_map, config) do
+    config
+    |> Enum.reduce(color_map, fn color, acc ->
+      Map.put(acc, String.to_atom(color), [
+        {Twix.Validate, :is_integer?},
+        {Twix.Validate, :is_opacity?}
+      ])
+    end)
   end
 end


### PR DESCRIPTION
Twix currently only recognizes the default colors, so if I use a custom color that I've defined in the tailwind.config.js file, it will not be merged.  This code change allows a developer to extend the colors that Twix uses by adding a list in their config.exs file: `config :twix, colors: ["primary"]

Example of current behavior:

tw "text-primary-500 text-green-200"
"text-primary-500 text-green-200"

Example of new behavior:
tw "text-primary-500 text-green-200"
"text-green-200"